### PR TITLE
bitbar: Amend PATH

### DIFF
--- a/bitbar/ambient.60s.sh
+++ b/bitbar/ambient.60s.sh
@@ -8,6 +8,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
+PATH="/usr/local/bin:$PATH" # to find Homebrew-installed fish
 
 WIDGET=$(/usr/local/bin/fish $DIR/../ambient-widgets | tr '\n' ' ')
 


### PR DESCRIPTION
[Homebrew](https://brew.sh/) installs `fish` to `/usr/local/bin`, but the `PATH` given to BitBar plugins is `/usr/bin:/bin:/usr/sbin:/sbin`. This adds `/usr/local/bin` to the `PATH` to make the plugin work.