### PR TITLE
Allow hiding BitBar plugin when inactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,17 @@ end, "$1", 31)
 
 Remember to add it to your `wibox` list! Search for `mytextclock` with a default configuration.
 
-### Bitbar
+### BitBar
 
-Link `bitbar/ambient.60s.sh` into your Bitbar plugin directory. 
+Link `bitbar/ambient.60s.sh` into your BitBar plugin directory.
 
 ```
 ln -s $(pwd)/bitbar/ambient.60s.sh ~/.bitbar
 ```
+
+You can put a file named `bitbar/plugins/ambient.json` in one of [the usual locations](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) (e.g. `~/.config`) to configure the plugin:
+
+- If `showIfEmpty` is false, the plugin will disappear entirely from your menu bar as long as you're not in a known network. Note that BitBar displays its own menu if none of the plugins are active. (Default: `true`)
 
 Why `fish`? Why not `bash` or `zsh`?
 ------------------------------------

--- a/bitbar/ambient.60s.sh
+++ b/bitbar/ambient.60s.sh
@@ -2,21 +2,35 @@
 
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
-  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
-  SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+    DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 PATH="/usr/local/bin:$PATH" # to find Homebrew-installed fish
 
+# look for config file in XDG config dirs
+printf '%s:\0' "${XDG_CONFIG_HOME:-"${HOME}/.config"}:${XDG_CONFIG_DIRS:-/etc/xdg}" | while IFS=: read -d: -r p; do
+    if [ -z "$config_file" ] && [ -r "$p/bitbar/plugins/ambient.json" ]; then
+        config_file="$p/bitbar/plugins/ambient.json"
+    fi
+done
+if [ -z "$config_file" ]; then
+    config='{}'
+else
+    config="$(cat "$config_file")"
+fi
+
 WIDGET=$(/usr/local/bin/fish $DIR/../ambient-widgets | tr '\n' ' ')
 
 if [ -z "$WIDGET" ]; then
-	echo "🚄"
-else 
-	echo $WIDGET
-	echo "---"
-	echo "Go to map|href=https://iceportal.de/karte"
-	echo $(/usr/local/bin/fish $DIR/../ambient | tr '\n' '\r\n')
+    if echo "$config" | jq -e 'if has("showIfEmpty") then .showIfEmpty else true end' > /dev/null; then
+        echo "🚄"
+    fi
+else
+    echo $WIDGET
+    echo "---"
+    echo "Go to map|href=https://iceportal.de/karte"
+    echo $(/usr/local/bin/fish $DIR/../ambient | tr '\n' '\r\n')
 fi

--- a/bitbar/ambient.60s.sh
+++ b/bitbar/ambient.60s.sh
@@ -11,15 +11,15 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 PATH="/usr/local/bin:$PATH" # to find Homebrew-installed fish
 
 # look for config file in XDG config dirs
-printf '%s:\0' "${XDG_CONFIG_HOME:-"${HOME}/.config"}:${XDG_CONFIG_DIRS:-/etc/xdg}" | while IFS=: read -d: -r p; do
-    if [ -z "$config_file" ] && [ -r "$p/bitbar/plugins/ambient.json" ]; then
-        config_file="$p/bitbar/plugins/ambient.json"
+while IFS=: read -d: -r p; do
+    if [ -z "$config_path" ] && [ -r "$p/bitbar/plugins/ambient.json" ]; then
+        config_path="$p/bitbar/plugins/ambient.json"
     fi
-done
-if [ -z "$config_file" ]; then
+done <<<$(printf '%s:\0' "${XDG_CONFIG_HOME:-"${HOME}/.config"}:${XDG_CONFIG_DIRS:-/etc/xdg}")
+if [ -z "$config_path" ]; then
     config='{}'
 else
-    config="$(cat "$config_file")"
+    config="$(cat "$config_path")"
 fi
 
 WIDGET=$(/usr/local/bin/fish $DIR/../ambient-widgets | tr '\n' ' ')


### PR DESCRIPTION
This adds the option to create a config file for the BitBar plugin at `bitbar/plugins/ambient.json` in one of the [XDG config dirs](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

Currently, the only config option is `showIfEmpty` which if set to `false` hides the BitBar plugin from the menu when `ambient-widgets` has no output. Since BitBar [shows its own menu when no plugin has any output](https://github.com/matryer/bitbar/issues/401), this is only really useful for people who use multiple BitBar plugins and would rather just see the ones that are currently active.